### PR TITLE
docs: minor fix to html renderer link text

### DIFF
--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -15,7 +15,7 @@ There is a small group of official plugins maintained, which provide useful func
 
 - [**Input Validator**](https://github.com/react-chatbotify-plugins/input-validator)
 - [**Markdown Renderer**](https://github.com/react-chatbotify-plugins/markdown-renderer)
-- [**Markdown Renderer**](https://github.com/react-chatbotify-plugins/html-renderer)
+- [**HTML Renderer**](https://github.com/react-chatbotify-plugins/html-renderer)
 - [**LLM Connector**](https://github.com/react-chatbotify-plugins/llm-connector)
 - [**Discord Live Chat**](https://github.com/react-chatbotify-plugins/discord-live-chat) (WIP)
 


### PR DESCRIPTION
#### Description

Fixes text for the HTML Renderer Link which is currently mislabelled as Markdown Renderer.

Closes #8 

#### What change does this PR introduce?

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Replace incorrect text with correct text

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)
    - This is a doc fix